### PR TITLE
Add draggable subscriber column ordering

### DIFF
--- a/src/resources/js/locales/de.json
+++ b/src/resources/js/locales/de.json
@@ -1649,6 +1649,17 @@
             "select_all_modal_title": "Alle ausgewählt",
             "select_all_modal_desc": "{count} Abonnenten aus dieser Liste ausgewählt. Sie können nun eine Massenaktion durchführen."
         },
+        "columns": {
+            "title": "Sichtbare Spalten",
+            "custom_fields": "Benutzerdefinierte Felder",
+            "active": "Aktive Spalten",
+            "available": "Verfügbare Spalten"
+        },
+        "column_settings": "Spalteneinstellungen",
+        "sort": {
+            "asc": "Aufsteigend",
+            "desc": "Absteigend"
+        },
         "import": {
             "title": "Abonnenten importieren",
             "subtitle": "Kontakte aus CSV-Datei importieren",

--- a/src/resources/js/locales/en.json
+++ b/src/resources/js/locales/en.json
@@ -1664,7 +1664,9 @@
         },
         "columns": {
             "title": "Visible columns",
-            "custom_fields": "Custom fields"
+            "custom_fields": "Custom fields",
+            "active": "Active columns",
+            "available": "Available columns"
         },
         "column_settings": "Column settings",
         "sort": {

--- a/src/resources/js/locales/es.json
+++ b/src/resources/js/locales/es.json
@@ -1660,6 +1660,17 @@
             "select_all_modal_title": "Todos seleccionados",
             "select_all_modal_desc": "Seleccionados {count} suscriptores de esta lista. Ahora puede realizar una operación masiva."
         },
+        "columns": {
+            "title": "Columnas visibles",
+            "custom_fields": "Campos personalizados",
+            "active": "Columnas activas",
+            "available": "Columnas disponibles"
+        },
+        "column_settings": "Configuración de columnas",
+        "sort": {
+            "asc": "Ascendente",
+            "desc": "Descendente"
+        },
         "import": {
             "title": "Importar suscriptores",
             "subtitle": "Importar contactos desde archivo CSV",

--- a/src/resources/js/locales/pl.json
+++ b/src/resources/js/locales/pl.json
@@ -1683,7 +1683,9 @@
         },
         "columns": {
             "title": "Widoczne kolumny",
-            "custom_fields": "Pola dodatkowe"
+            "custom_fields": "Pola dodatkowe",
+            "active": "Aktywne kolumny",
+            "available": "Dostępne kolumny"
         },
         "column_settings": "Ustawienia kolumn",
         "sort": {


### PR DESCRIPTION
## Summary
- add active/available column lists with drag-and-drop ordering for subscribers
- persist column order in local storage and render tables using the configured layout
- update translations for the new column settings labels
